### PR TITLE
Catch exceptions raised in `parallelize_setup` and ensure test fail when they occur

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization.rb
+++ b/activesupport/lib/active_support/testing/parallelization.rb
@@ -83,11 +83,9 @@ module ActiveSupport
               reporter = job[2]
               result   = Minitest.run_one_method(klass, method)
 
-              begin
-                if setup_exception.present?
-                  result.failures.prepend Minitest::UnexpectedError.new(setup_exception)
-                end
+              add_setup_exception(result, setup_exception) if setup_exception.present?
 
+              begin
                 queue.record(reporter, result)
               rescue DRb::DRbConnError
                 result.failures.each do |failure|
@@ -109,6 +107,12 @@ module ActiveSupport
       def shutdown
         @queue_size.times { @queue << nil }
         @pool.each { |pid| Process.waitpid pid }
+      end
+
+      private
+
+      def add_setup_exception(result, setup_exception)
+        result.failures.prepend Minitest::UnexpectedError.new(setup_exception)
       end
     end
   end


### PR DESCRIPTION
### Summary

The changes here ensure that we catch any `StandardException`s that occur during the `after_fork` call (blocks passed into `parallelize_setup`) and record those exceptions with the test results.  This is work towards resolving https://github.com/rails/rails/issues/35835.  

This results in marking all of the tests as failed to bring attention to the issue & ensure it is addressed before proceeding.

/cc #35835